### PR TITLE
README: add link to LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you have issues, please let us know from the above page.
 ## License
 
 The bundle may be distributed and/or modified under the terms of
-the 3-clause BSD license (see LICENSE).
+the 3-clause BSD license (see [LICENSE](./LICENSE)).
 
 ## Release Date
 


### PR DESCRIPTION
MarkdownビューアやGitHubの画面ではLICENSEファイルへのリンクになっていると便利かと思いました。