### PR TITLE
Travis CIの設定を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 os:
   - osx
+  - linux
+dist: trusty
+sudo: required
+before_install:
+  - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/install-tex.sh
+  - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/tlmgr.sh
+  - chmod +x install-tex.sh tlmgr.sh
 install:
-  - curl -L -O http://mirrors.concertpass.com/tex-archive/systems/mac/mactex/BasicTeX.pkg
-  - sudo installer -pkg BasicTeX.pkg -target /
-  - rm BasicTeX.pkg
-  - export PATH=$PATH:/usr/texbin
-  - sudo tlmgr update --self --all
-  - sudo tlmgr install collection-langjapanese collection-fontsrecommended
+  - . ./install-tex.sh
+  - ./tlmgr.sh update --self --all
+  - ./tlmgr.sh install collection-langjapanese collection-fontsrecommended
 script:
-  - make clean
+  - make
+  - rm -f *.dvi
+  - fmtutil --byfmt platex
   - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+os:
+  - osx
+install:
+  - curl -L -O http://mirrors.concertpass.com/tex-archive/systems/mac/mactex/BasicTeX.pkg
+  - sudo installer -pkg BasicTeX.pkg -target /
+  - rm BasicTeX.pkg
+  - export PATH=$PATH:/usr/texbin
+  - sudo tlmgr update --self --all
+  - sudo tlmgr install collection-langjapanese collection-fontsrecommended
+script:
+  - make clean
+  - make all

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # platex
 
+[![Build Status](https://travis-ci.org/texjporg/platex.svg?branch=master)](https://travis-ci.org/texjporg/platex)
+
 The bundle provides pLaTeX2e and miscellaneous macros for pTeX and e-pTeX.
 
 The bundle is a community edition forked from the original ASCII edition


### PR DESCRIPTION
#11 で議論があったことですが、ドキュメントを自動でデプロイするとかは一旦おいておいて、ひとまず変更した後で正しくコンパイルできるのかについて検証するTravis CIの設定ファイルを追加しました。

- [実行されたビルドのログ](https://travis-ci.org/y-yu/platex/jobs/155533281)
- [Travis CIの設定ファイル](https://travis-ci.org/y-yu/platex/jobs/155533281/config)

もしこの変更を取り込む場合は、次のWebサイトに従ってTravis CIとGithubのリポジトリの設定をしていただきたく思います。

- https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A

なにか不明な点がありましたら、お気軽に質問してください。