### PR TITLE
use \chardef to define \pltx@gluetype and \pltx@jfmgluesubtype

### DIFF
--- a/plcore.dtx
+++ b/plcore.dtx
@@ -215,8 +215,17 @@
 \ifx\lastnodesubtype\@undefined
   \let\removejfmglue\@undefined
 \else
-  \def\pltx@gluetype{11}
-  \def\pltx@jfmgluesubtype{21}
+  \setbox0\hbox{%
+    \ifdefined\ucs %% upTeX check
+      \jfont\tenmin=upjisr-h at 9.62216pt
+    \else
+      \jfont\tenmin=min10
+    \fi\tenmin
+    ）\null\setbox0\lastbox
+    \global\chardef\pltx@gluetype\lastnodetype
+    \global\chardef\pltx@jfmgluesubtype\lastnodesubtype
+  }
+  \setbox0=\box\voidb@x
   \protected\def\removejfmglue{%
     \ifnum\lastnodetype=\pltx@gluetype\relax
       \ifnum\lastnodesubtype=\pltx@jfmgluesubtype\relax


### PR DESCRIPTION
\removejfmglue で使う \pltx@gluetype, \pltx@jfmgluesubtype がハードコードされているので，実際の日本語フォント (min10 or upjisr-h) を使って定義するようにしました．