### PR TITLE
LaTeX2e 2021-11-15 対応

### DIFF
--- a/platexrelease.dtx
+++ b/platexrelease.dtx
@@ -351,6 +351,7 @@ of this package available from CTAN}
       some critical bugs. We advise you to\MessageBreak
       select another format date}
 \plIncludeInRelease{2017/10/28}{\PackageWarning}{pLaTeX Info}%
+  % * <2021-11-15>
   % * <2021-06-01>+2
   % * <2021-06-01>+1
   % * <2021-06-01>

--- a/platexrelease.sty
+++ b/platexrelease.sty
@@ -18,9 +18,9 @@
 %% 
 %% File: plvers.dtx
 \edef\p@known@latexreleaseversion
-   {2021-06-01}
+   {2021-11-15}
 \edef\platexreleaseversion
-   {2021-06-01}
+   {2021-11-15}
 \newif\if@plincludeinrelease
 \@plincludeinreleasefalse
 \def\plIncludeInRelease#1{%
@@ -146,6 +146,7 @@ of this package available from CTAN}
       some critical bugs. We advise you to\MessageBreak
       select another format date}
 \plIncludeInRelease{2017/10/28}{\PackageWarning}{pLaTeX Info}%
+  % * <2021-11-15>
   % * <2021-06-01>+2
   % * <2021-06-01>+1
   % * <2021-06-01>
@@ -3162,6 +3163,30 @@ of this package available from CTAN}
      \@ifnextchar [\@xfootnotenext
        {\protected@xdef\@thefnmark{\thempfn}%
     \@footnotetext}}
+\plEndIncludeInRelease
+\plIncludeInRelease{2021/11/15}{\@footnotetext}
+                   {Adapt to ltfloat.dtx (2021-10-14 v1.2g)}%
+\long\def\@footnotetext#1{%
+  \ifydir\def\@tempa{\yoko}\else\def\@tempa{\tate}\fi
+  \insert\footins{\@tempa%
+    \reset@font\footnotesize
+    \interlinepenalty\interfootnotelinepenalty
+    \splittopskip\footnotesep
+    \splitmaxdepth \dp\strutbox \floatingpenalty \@MM
+    \hsize\columnwidth \@parboxrestore
+    \def\@currentcounter{footnote}%
+    \protected@edef\@currentlabel{%
+       \csname p@footnote\endcsname\@thefnmark
+    }%
+    \color@begingroup
+      \@makefntext{%
+        \rule\z@\footnotesep\ignorespaces#1\@finalstrut\strutbox}%
+    \par
+    \color@endgroup}\ifhmode\null\fi
+    \ifnum\pltx@foot@penalty=\z@\else
+      \penalty\pltx@foot@penalty
+      \pltx@foot@penalty\z@
+    \fi}
 \plEndIncludeInRelease
 \plIncludeInRelease{2021/06/01}{\@footnotetext}
                    {Adapt to ltfloat.dtx (2021-03-03 v1.2f)}%

--- a/plcore.dtx
+++ b/plcore.dtx
@@ -136,13 +136,14 @@
 %    \cs{@outputbox}の寸法補正のコードを別命令として切り出した}
 % \changes{v1.3j}{2021/06/03}{巻戻しコードのエラー修正}
 % \changes{v1.3k}{2021/06/28}{内部Unicodeの時のみを検出}
+% \changes{v1.3l}{2021/12/08}{\LaTeXe~2021-11-15に伴う修正}
 % \fi
 %
 % \iffalse
 %<*driver>
 \NeedsTeXFormat{pLaTeX2e}
 % \fi
-\ProvidesFile{plcore.dtx}[2021/06/28 v1.3k pLaTeX core file]
+\ProvidesFile{plcore.dtx}[2021/12/08 v1.3l pLaTeX core file]
 % \iffalse
 \documentclass{jltxdoc}
 \GetFileInfo{plcore.dtx}
@@ -1896,9 +1897,11 @@
 % \changes{v1.0a}{1995/04/07}{組方向の判定をボックスの外でするようにした}
 % \changes{v1.3h}{2021/03/14}{\LaTeXe~2021-06-01では\cs{par}が入る
 %    (sync with ltfloat.dtx 2021/02/10 v1.2e)}
+% \changes{v1.3l}{2021/12/08}{\LaTeXe~2021-11-15では\cs{@currentcounter}を
+%    明示的に設定する(sync with ltfloat.dtx 2021/10/14 v1.2g)}
 %    \begin{macrocode}
-%<platexrelease>\plIncludeInRelease{2021/06/01}{\@footnotetext}
-%<platexrelease>                   {Adapt to ltfloat.dtx (2021-03-03 v1.2f)}%
+%<platexrelease>\plIncludeInRelease{2021/11/15}{\@footnotetext}
+%<platexrelease>                   {Adapt to ltfloat.dtx (2021-10-14 v1.2g)}%
 %<*plcore|platexrelease>
 %    \end{macrocode}
 %    \begin{macrocode}
@@ -1910,6 +1913,7 @@
     \splittopskip\footnotesep
     \splitmaxdepth \dp\strutbox \floatingpenalty \@MM
     \hsize\columnwidth \@parboxrestore
+    \def\@currentcounter{footnote}%
     \protected@edef\@currentlabel{%
        \csname p@footnote\endcsname\@thefnmark
     }%
@@ -1938,6 +1942,29 @@
 %    \end{macrocode}
 %    \begin{macrocode}
 %</plcore|platexrelease>
+%<platexrelease>\plEndIncludeInRelease
+%<platexrelease>\plIncludeInRelease{2021/06/01}{\@footnotetext}
+%<platexrelease>                   {Adapt to ltfloat.dtx (2021-03-03 v1.2f)}%
+%<platexrelease>\long\def\@footnotetext#1{%
+%<platexrelease>  \ifydir\def\@tempa{\yoko}\else\def\@tempa{\tate}\fi
+%<platexrelease>  \insert\footins{\@tempa%
+%<platexrelease>    \reset@font\footnotesize
+%<platexrelease>    \interlinepenalty\interfootnotelinepenalty
+%<platexrelease>    \splittopskip\footnotesep
+%<platexrelease>    \splitmaxdepth \dp\strutbox \floatingpenalty \@MM
+%<platexrelease>    \hsize\columnwidth \@parboxrestore
+%<platexrelease>    \protected@edef\@currentlabel{%
+%<platexrelease>       \csname p@footnote\endcsname\@thefnmark
+%<platexrelease>    }%
+%<platexrelease>    \color@begingroup
+%<platexrelease>      \@makefntext{%
+%<platexrelease>        \rule\z@\footnotesep\ignorespaces#1\@finalstrut\strutbox}%
+%<platexrelease>    \par
+%<platexrelease>    \color@endgroup}\ifhmode\null\fi
+%<platexrelease>    \ifnum\pltx@foot@penalty=\z@\else
+%<platexrelease>      \penalty\pltx@foot@penalty
+%<platexrelease>      \pltx@foot@penalty\z@
+%<platexrelease>    \fi}
 %<platexrelease>\plEndIncludeInRelease
 %<platexrelease>\plIncludeInRelease{2016/09/08}{\@footnotetext}
 %<platexrelease>                   {Allow break after \footnote (more fix)}%

--- a/plcore.ltx
+++ b/plcore.ltx
@@ -34,8 +34,8 @@
 \fi
 \def\pfmtname{pLaTeX2e}
 \def\pfmtversion
-   {2021-06-01}
-\def\ppatch@level{2}
+   {2021-11-15}
+\def\ppatch@level{0}
 \edef\platexBANNER{\noexpand\platexNILa
                    \the\everyjob % LaTeX banner and delayed codes
                    \noexpand\platexNILb}
@@ -2187,6 +2187,7 @@
     \splittopskip\footnotesep
     \splitmaxdepth \dp\strutbox \floatingpenalty \@MM
     \hsize\columnwidth \@parboxrestore
+    \def\@currentcounter{footnote}%
     \protected@edef\@currentlabel{%
        \csname p@footnote\endcsname\@thefnmark
     }%

--- a/plvers.dtx
+++ b/plvers.dtx
@@ -100,12 +100,13 @@
 % \changes{v1.1w}{2020/09/30}{\LaTeX\ \texttt{!<2020-10-01!>}版対応確認}
 % \changes{v1.1x}{2020/10/07}{フックシステムが利用可能かどうか判定}
 % \changes{v1.1y}{2021/06/27}{\LaTeX\ \texttt{!<2021-06-01!>}版ほぼ対応}
+% \changes{v1.1z}{2021/12/08}{\LaTeX\ \texttt{!<2021-11-15!>}版ほぼ対応}
 % \fi
 %
 % \iffalse
 %<*driver>
 % \fi
-\ProvidesFile{plvers.dtx}[2021/06/27 v1.1y pLaTeX Kernel (Version Info)]
+\ProvidesFile{plvers.dtx}[2021/12/08 v1.1z pLaTeX Kernel (Version Info)]
 % \iffalse
 \documentclass{jltxdoc}
 \GetFileInfo{plvers.dtx}
@@ -147,6 +148,7 @@
 % \changes{v1.1s}{2020/03/14}{\LaTeX\ \texttt{!<2020-02-02!> PL5}版対応確認}
 % \changes{v1.1w}{2020/09/30}{\LaTeX\ \texttt{!<2020-10-01!>}版対応確認}
 % \changes{v1.1y}{2021/06/27}{\LaTeX\ \texttt{!<2021-06-01!>}版ほぼ対応}
+% \changes{v1.1z}{2021/12/08}{\LaTeX\ \texttt{!<2021-11-15!>}版ほぼ対応}
 %    \begin{macrocode}
 %<*2ekernel>
 %\def\fmtname{LaTeX2e}
@@ -155,7 +157,7 @@
 %<latexrelease>\edef\latexreleaseversion
 %<platexrelease>\edef\p@known@latexreleaseversion
 %<*2ekernel|latexrelease|platexrelease>
-   {2021-06-01}
+   {2021-11-15}
 %</2ekernel|latexrelease|platexrelease>
 %    \end{macrocode}
 %
@@ -196,10 +198,10 @@
 %</plcore>
 %<platexrelease>\edef\platexreleaseversion
 %<*plcore|platexrelease>
-   {2021-06-01}
+   {2021-11-15}
 %</plcore|platexrelease>
 %<*plcore>
-\def\ppatch@level{2}
+\def\ppatch@level{0}
 %</plcore>
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
LaTeX2e 2021-11-15 での変更点を反映しました。

変更点は、

* `\@footnotetext` で `\@currentcounter` を明示的に設定する

の一点です。