### PR TITLE
ドキュメントをa4paperにする

### DIFF
--- a/exppl2e.sty
+++ b/exppl2e.sty
@@ -48,7 +48,7 @@
 \else
 % case 2: This file pretends to be a document
   \RequirePackage{plautopatch}
-  \documentclass[dvipdfmx]{jltxdoc}
+  \documentclass[dvipdfmx,a4paper]{jltxdoc}
   \title{Experimental p\LaTeXe}
   \author{Japanese \TeX\ Development Community}
   \begin{document}

--- a/jclasses.dtx
+++ b/jclasses.dtx
@@ -143,7 +143,7 @@
 %<*driver>
 ]
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{jclasses.dtx}
 \title{p\LaTeXe{}の標準クラス\space\fileversion}
 \author{Ken Nakano}

--- a/jltxdoc.dtx
+++ b/jltxdoc.dtx
@@ -27,7 +27,7 @@
 %<class>\ProvidesClass{jltxdoc}[2017/09/24 v1.0d Standard pLaTeX file]
 %<*driver>
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{jltxdoc.cls}
 \title{p\LaTeXe{}ドキュメント記述用クラス\space\fileversion}
 \author{Ken Nakano}

--- a/kinsoku.dtx
+++ b/kinsoku.dtx
@@ -32,7 +32,7 @@
   [2021/03/04 v1.0d pLaTeX Kernel (community edition)]
 % \iffalse
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{kinsoku.dtx}
 \title{禁則パラメータ\space\fileversion}
 \author{Ken Nakano}

--- a/pl209.dtx
+++ b/pl209.dtx
@@ -30,7 +30,7 @@
 %</package>
 %<*driver>
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{pl209.dtx}
 \title{p\LaTeXe\\2.09互換モード用マクロ\space\fileversion}
 \author{Ken Nakano \& Hideaki Togashi}

--- a/platex.dtx
+++ b/platex.dtx
@@ -150,7 +150,7 @@
 \ProvidesFile{platex.dtx}[2022/03/06 v1.1e pLaTeX document file]
 % \iffalse
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \usepackage{plext}
 \GetFileInfo{platex.dtx}
 \ifJAPANESE
@@ -1133,7 +1133,7 @@
 %\fi
 %    \begin{macrocode}
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \AddToHook{env/macro/before}{\catcode`\_=12\relax}
 \AddToHook{env/macro/after}{\catcode`\_=8\relax}
 \usepackage{plext}

--- a/platexrelease.dtx
+++ b/platexrelease.dtx
@@ -47,7 +47,7 @@
               (including releases up to \platexreleaseversion)]
 %<*driver>
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{platexrelease.dtx}
 \author{Japanese \TeX\ Development Community}
 \title{The \textsf{platexrelease} package}

--- a/plcore.dtx
+++ b/plcore.dtx
@@ -146,7 +146,7 @@
 \ProvidesFile{plcore.dtx}[2021/12/08 v1.3l pLaTeX core file]
 % \iffalse
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{plcore.dtx}
 \title{p\LaTeXe{}の拡張\space\fileversion}
 \author{Ken Nakano \& Hideaki Togashi}

--- a/plexpl3.dtx
+++ b/plexpl3.dtx
@@ -18,7 +18,7 @@
 \NeedsTeXFormat{pLaTeX2e}
 \ProvidesFile{plexpl3.dtx}[2020/09/28 v1.0 expl3 additions]
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{plexpl3.dtx}
 \author{Japanese \TeX\ Development Community}
 \title{The \textsf{plexpl3} package}

--- a/plext.dtx
+++ b/plext.dtx
@@ -97,7 +97,7 @@
    [2020/10/07 v1.2m pLaTeX package file (community edition)]
 %<*driver>
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \usepackage{plext}
 \GetFileInfo{plext.dtx}
 \title{p\LaTeXe{}拡張パッケージ\space\fileversion}

--- a/plfonts.dtx
+++ b/plfonts.dtx
@@ -198,7 +198,7 @@
 \ProvidesFile{plfonts.dtx}[2021/06/27 v1.7n pLaTeX New Font Selection Scheme]
 % \iffalse
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{plfonts.dtx}
 \title{p\LaTeXe{}のフォントコマンド\space\fileversion}
 \author{Ken Nakano \& Hideaki Togashi}

--- a/plvers.dtx
+++ b/plvers.dtx
@@ -109,7 +109,7 @@
 \ProvidesFile{plvers.dtx}[2021/12/08 v1.1z pLaTeX Kernel (Version Info)]
 % \iffalse
 \RequirePackage{plautopatch}
-\documentclass[dvipdfmx]{jltxdoc}
+\documentclass[dvipdfmx,a4paper]{jltxdoc}
 \GetFileInfo{plvers.dtx}
 \author{Ken Nakano \& Hideaki Togashi}
 \title{\filename}


### PR DESCRIPTION
現在のドキュメントはレターサイズ（articleクラスのデフォルト）でタイプセットされたうえでA4サイズのPDFに変換されたものになっています。

これは少々奇妙なので、タイプセットもA4サイズで行うようにしたいと思います。

----

なお現状、最新のTeX Liveでドキュメントをビルドすると、
  * pldoc.pdfはhyperref(?)によって正しくPDFのサイズが設定されるためかレターサイズになり、
  * platex.pdf等はタイプセットもA4になります。
    - texmf-dist/tex/latex/base/ltxdoc.cfgが自動的に読み込まれこの中の`\PassOptionsToClass{a4paper}{article}`によってA4用紙に設定されるためのようです。
    - pldoc.pdfはカレントディレクトリにltxdoc.cfgを生成したうえでタイプセットするので影響を受けないようです。
